### PR TITLE
fix pathfinding algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# custom
+layout.jpg
+
 # dependencies
 /node_modules
 /.pnp

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "priorityqueuejs": "^2.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "priorityqueuejs": "^2.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build", 
+    "deploy": "gh-pages -d build",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/src/Pathing.js
+++ b/src/Pathing.js
@@ -39,6 +39,27 @@ const graph = {
     EV3: { EV2: 1 },
 };
 
+
+function contains(queue, callback) {
+  let found = false;
+  const tempQueue = new PriorityQueue(queue.comparator);
+
+  while (!queue.isEmpty()) {
+    const element = queue.deq();
+    if (callback(element)) {
+      found = true;
+    }
+    tempQueue.enq(element); // Re-enq to maintain the queue state
+  }
+
+  // Restore the original queue state
+  while (!tempQueue.isEmpty()) {
+    queue.enq(tempQueue.deq());
+  }
+
+  return found;
+}
+
 function getPath(start, end) {
 
     if(start === '' || end === ''){
@@ -61,15 +82,18 @@ function getPath(start, end) {
     while (!nodeQueue.isEmpty()) {
 
         let currNode = nodeQueue.deq()['node'];
+        console.log(`current queue: ${JSON.stringify(nodeQueue._elements)}`) 
+        console.log(`current dists: ${JSON.stringify(dists)}`)
 
-        if(currNode === end)
-            break;
+        //if(currNode === end)
+         //   break;
 
         // update distances and prev node
         for (var [node, dist] of Object.entries(graph[currNode])) {
             const newDist = dists[currNode] + dist;
 
-            if (!visited.has(node) &&  newDist < dists[node]) {
+            if (newDist < dists[node]) {
+                console.log(`updating distance for ${JSON.stringify(node)} from ${dists[node]} to ${newDist}`)
                 dists[node] = newDist;
                 prevs[node] = currNode;
             }
@@ -80,7 +104,8 @@ function getPath(start, end) {
 
         // chooses new currNode
         for (var neighbor in graph[currNode]) {
-            if (!visited.has(neighbor)) {
+            if (!visited.has(neighbor) && !contains(nodeQueue, ((entry) => entry.node === neighbor))) {
+                console.log(`currNode: ${currNode}, Enqueuing: ${node}, Distance: ${dists[node]}`);
                 nodeQueue.enq({ node: neighbor, dist: dists[neighbor] });
             }
         }


### PR DESCRIPTION
Fixed bug in pathfinding algorithm - previously ended search upon finding a path to the destination node but utilized a DFS-like search algorithm. This caused the search to return the first path it found, but since it used DFS the path was just the top-most path. Also removed logic preventing visited nodes from being searched (would not have been a problem with a BFS-like implementation of Dijkstra's algorithm, but it does not work for DFS-like searching)